### PR TITLE
Completeness stats query

### DIFF
--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -53,7 +53,7 @@ paths:
                     $ref: "#/components/responses/404NotFoundError"
                 5XX:
                     $ref: "#/components/responses/5xxServerError"
-    /genomic-completeness:
+    /genomic_completeness:
         get:
             summary: Retrieve summary statistics on genomic data
             description: Retrieve summary statistics on genomic data
@@ -197,7 +197,7 @@ components:
             properties:
                 results:
                     type: object
-                    description: Summary statistics of program id (key) to number of complete cases (value)
+                    description: Summary statistics of program id (key) to another object with number of complete genomic and transcriptome cases
         # ERROR SCHEMAS
         Error:
             type: object

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -42,7 +42,7 @@ paths:
             operationId: query_operations.query
             responses:
                 200:
-                    description: Retrieve info about the Query service
+                    description: Retrieved donor information
                     content:
                         application/json:
                             schema:
@@ -53,6 +53,21 @@ paths:
                     $ref: "#/components/responses/404NotFoundError"
                 5XX:
                     $ref: "#/components/responses/5xxServerError"
+    /genomic-completeness:
+        get:
+            summary: Retrieve summary statistics on genomic data
+            description: Retrieve summary statistics on genomic data
+            operationId: query_operations.genomic_completeness
+            responses:
+                200:
+                    description: Retrieved genomic completness information
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/GenomicCompletenessBody'
+                5XX:
+                    $ref: "#/components/responses/5xxServerError"
+                    
 components:
     parameters:
         treatmentParam:
@@ -176,6 +191,13 @@ components:
                 prev:
                     type: string
                     description: URL to grab the previous set of results
+        GenomicCompletenessBody:
+            type: object
+            description: Genomic completeness statistics
+            properties:
+                results:
+                    type: object
+                    description: Summary statistics of program id (key) to number of complete cases (value)
         # ERROR SCHEMAS
         Error:
             type: object

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -284,7 +284,7 @@ def genomic_completeness():
     for sample in samples:
         program_id = sample['program_id']
         if program_id not in retVal:
-            retVal[program_id] = 0
+            retVal[program_id] = { 'genomes': 0, 'transcriptomes': 0, 'all': 0 }
         sample_id = sample['submitter_sample_id']
 
         # Check with HTSGet to see whether or not this sample is complete
@@ -293,7 +293,12 @@ def genomic_completeness():
             headers=request.headers)
         if r.ok:
             r_json = r.json()
+            retVal[program_id]
             if len(r_json['genomes']) > 0 and len(r_json['transcriptomes']) > 0:
-                retVal[program_id] += 1
+                retVal[program_id]['all'] += 1
+            if len(r_json['genomes']) > 0:
+                retVal[program_id]['genomes'] += 1
+            if len(r_json['transcriptomes']) > 0:
+                retVal[program_id]['transcriptomes'] += 1
 
     return retVal, 200


### PR DESCRIPTION
## Ticket(s)

- [DIG-1191](https://candig.atlassian.net/browse/DIG-1191)

## Description

- This adds an endpoint to the query microservice that queries HTSGet for completeness stats on all known samples.

## Expected Behaviour

- You can query things at query/completeness-stats, with the following:
1. First, ingest some clinical & genomic data, then:
2. `curl "http://candig.docker.internal:1236/genomic-completeness" -H "Authorization: Bearer $TOKEN"`
3. The response should be a dictionary of program IDs to number of complete samples

## Types of Change(s)

-   [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
-   [x] ✨ New feature (non-breaking change that adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## Has it been tested for:

-   [x] My change requires a change to the documentation
-   [x] I have updated the documentation accordingly
-   [x] Locally tested


[DIG-1191]: https://candig.atlassian.net/browse/DIG-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ