### PR TITLE
DIG-1377: Be consistent in our use of candig user inside containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,10 @@ COPY . /app/query_server
 
 WORKDIR /app/query_server
 
+RUN chown -R candig:candig /app/query_server
+
+USER candig
+
 RUN touch initial_setup
 
 ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -133,7 +133,7 @@ components:
             example: 10
             required: false
             schema:
-                $ref: '#/components/schemas/Field'
+                $ref: '#/components/schemas/IntField'
         pageParam:
             in: query
             name: page
@@ -141,7 +141,7 @@ components:
             example: 1
             required: false
             schema:
-                $ref: '#/components/schemas/Field'
+                $ref: '#/components/schemas/IntField'
 #        sessionIDParam:
 #            in: query
 #            name: session_id
@@ -160,6 +160,9 @@ components:
         Field:
             type: string
             description: Acceptable requested string for querying
+        IntField:
+            type: integer
+            description: Acceptable integer for querying
         QueryBody:
             type: object
             description: Query response

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -53,7 +53,7 @@ paths:
                     $ref: "#/components/responses/404NotFoundError"
                 5XX:
                     $ref: "#/components/responses/5xxServerError"
-    /genomic-completeness:
+    /genomic_completeness:
         get:
             summary: Retrieve summary statistics on genomic data
             description: Retrieve summary statistics on genomic data
@@ -200,7 +200,7 @@ components:
             properties:
                 results:
                     type: object
-                    description: Summary statistics of program id (key) to number of complete cases (value)
+                    description: Summary statistics of program id (key) to another object with number of complete genomic and transcriptome cases
         # ERROR SCHEMAS
         Error:
             type: object

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -42,7 +42,7 @@ paths:
             operationId: query_operations.query
             responses:
                 200:
-                    description: Retrieve info about the Query service
+                    description: Retrieved donor information
                     content:
                         application/json:
                             schema:
@@ -53,6 +53,21 @@ paths:
                     $ref: "#/components/responses/404NotFoundError"
                 5XX:
                     $ref: "#/components/responses/5xxServerError"
+    /genomic-completeness:
+        get:
+            summary: Retrieve summary statistics on genomic data
+            description: Retrieve summary statistics on genomic data
+            operationId: query_operations.genomic_completeness
+            responses:
+                200:
+                    description: Retrieved genomic completness information
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/GenomicCompletenessBody'
+                5XX:
+                    $ref: "#/components/responses/5xxServerError"
+                    
 components:
     parameters:
         treatmentParam:
@@ -179,6 +194,13 @@ components:
                 prev:
                     type: string
                     description: URL to grab the previous set of results
+        GenomicCompletenessBody:
+            type: object
+            description: Genomic completeness statistics
+            properties:
+                results:
+                    type: object
+                    description: Summary statistics of program id (key) to number of complete cases (value)
         # ERROR SCHEMAS
         Error:
             type: object

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -122,7 +122,7 @@ def get_summary_stats(donors, headers):
             patients_per_cohort[program_id] += 1
         else:
             patients_per_cohort[program_id] = 1
-    
+
     return {
         'age_at_diagnosis': age_at_diagnosis,
         'treatment_type_count': treatment_type_count,
@@ -296,3 +296,31 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     # Essentially we want to go session ID -> list of donors
     # and then paginate the list of donors, calling donors_with_clinical_data on each before returning
     return fix_dicts(full_data), 200
+
+@app.route('/genomic_completeness')
+def genomic_completeness():
+    params = { 'page_size': PAGE_SIZE }
+    url = f"{config.KATSU_URL}/v2/authorized/sample_registrations/"
+    r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params)}",
+        # Reuse their bearer token
+        headers=request.headers), 'Katsu sample registrations')
+    samples = r['results']
+
+    retVal = {}
+    for sample in samples:
+        program_id = sample['program_id']
+        if program_id not in retVal:
+            retVal[program_id] = 0
+        sample_id = sample['submitter_sample_id']
+
+        # Check with HTSGet to see whether or not this sample is complete
+        r = requests.get(f"{config.HTSGET_URL}/htsget/v1/samples/{sample_id}",
+            # Reuse their bearer token
+            headers=request.headers)
+        if r.ok:
+            r_json = r.json()
+            if len(r_json['genomes']) > 0 and len(r_json['transcriptomes']) > 0:
+                retVal[program_id] += 1
+
+    return retVal, 200
+

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -69,15 +69,21 @@ def get_summary_stats(donors, headers):
     for diagnosis in diagnoses:
         if diagnosis['submitter_donor_id'] in donor_date_of_births:
             # Make sure we have both dates necessary for this analysis
-            if 'date_of_diagnosis' not in diagnosis:
+            if 'date_of_diagnosis' not in diagnosis or diagnosis['date_of_diagnosis'] is None:
                 print(f"Unable to find diagnosis date for {diagnosis['submitter_donor_id']}")
+                add_or_increment(age_at_diagnosis, 'Unknown')
                 continue
-            if diagnosis['submitter_donor_id'] not in donor_date_of_births:
+            if diagnosis['submitter_donor_id'] not in donor_date_of_births or donor_date_of_births[diagnosis['submitter_donor_id']] is None:
                 print(f"Unable to find date of birth for {diagnosis['submitter_donor_id']}")
+                add_or_increment(age_at_diagnosis, 'Unknown')
                 continue
 
             diag_date = diagnosis['date_of_diagnosis'].split('-')
             birth_date = donor_date_of_births[diagnosis['submitter_donor_id']].split('-')
+            if len(diag_date) < 2 or len(birth_date) < 2:
+                print(f"Unable to find date of birth/diagnosis for {diagnosis['submitter_donor_id']}")
+                add_or_increment(age_at_diagnosis, 'Unknown')
+                continue
 
             age = int(diag_date[0]) - int(birth_date[0])
             if int(diag_date[1]) >= int(birth_date[1]):

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -310,7 +310,7 @@ def genomic_completeness():
     for sample in samples:
         program_id = sample['program_id']
         if program_id not in retVal:
-            retVal[program_id] = 0
+            retVal[program_id] = { 'genomes': 0, 'transcriptomes': 0, 'all': 0 }
         sample_id = sample['submitter_sample_id']
 
         # Check with HTSGet to see whether or not this sample is complete
@@ -319,8 +319,13 @@ def genomic_completeness():
             headers=request.headers)
         if r.ok:
             r_json = r.json()
+            retVal[program_id]
             if len(r_json['genomes']) > 0 and len(r_json['transcriptomes']) > 0:
-                retVal[program_id] += 1
+                retVal[program_id]['all'] += 1
+            if len(r_json['genomes']) > 0:
+                retVal[program_id]['genomes'] += 1
+            if len(r_json['transcriptomes']) > 0:
+                retVal[program_id]['transcriptomes'] += 1
 
     return retVal, 200
 

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -167,6 +167,24 @@ def query_htsget_pos(headers, assembly, chrom, start=0, end=10000000):
         headers=headers,
         json=payload), 'HTSGet position')
 
+# The return value does not like None being used as a key, so this helper function recursively
+# goes through the dictionary provided, and changes all keys to strings
+# NB: This overwrites any keys that were previously not strings, and can cause data deletion
+# if there was two keys e.g. 12 and "12"
+def fix_dicts(to_fix):
+    if isinstance(to_fix, dict):
+        new_dict = {}
+        for key, value in to_fix.items():
+            new_dict[str(key)] = fix_dicts(value)
+        return new_dict
+    elif isinstance(to_fix, list):
+        new_list = []
+        for value in to_fix:
+            new_list.append(fix_dicts(value))
+        return new_list
+    else:
+        return to_fix
+
 @app.route('/query')
 def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", hormone_therapy="", chrom="", gene="", page=0, page_size=10, assembly="hg38", exclude_cohorts=[], session_id=""):
     # NB: We're still doing table joins here, which is probably not where we want to do them
@@ -260,7 +278,7 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     ret_donors = [donor['submitter_donor_id'] for donor in donors[(page*page_size):((page+1)*page_size)]]
     if len(donors) > 0:
         params = {
-            'page_size': PAGE_SIZE,
+            'page_size': page_size,
             'donors': ','.join(ret_donors)
         }
         r = requests.get(f"{config.KATSU_URL}/v2/authorized/donor_with_clinical_data/?{urllib.parse.urlencode(params)}",
@@ -277,4 +295,4 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     # Add prev and next parameters to the repsonse, appending a session ID.
     # Essentially we want to go session ID -> list of donors
     # and then paginate the list of donors, calling donors_with_clinical_data on each before returning
-    return full_data, 200
+    return fix_dicts(full_data), 200


### PR DESCRIPTION
## Tickets
[DIG-1377](https://candig.atlassian.net/browse/DIG-1377)

## Description

Adds the CanDIG user and group during the Dockerfile initialization, and makes sure that the stack is being run as the CanDIG user. This should ideally not change anything, and is only another layer of security (the root user in Docker is actually the same root as on your local filesystem? And we're just relying on Docker isolating the child process enough to prevent it from affecting things outside the container.) This is one PR out of six doing more-or-less the same thing.

[DIG-1377]: https://candig.atlassian.net/browse/DIG-1377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ