### PR TITLE
DIG-1149: Update Alpine to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN apk add --no-cache \
 	curl \
 	curl-dev \
 	yaml-dev \
-	libressl-dev \
 	pcre-dev \
 	git \
 	sqlite


### PR DESCRIPTION
Similar to https://github.com/CanDIG/federation_service/pull/45: libressl-dev causes a conflict, but doesn't seem to be explicitly needed anyway.