### PR TITLE
DIG-1144: update to python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN apk add --no-cache \
 	curl \
 	curl-dev \
 	yaml-dev \
-	libressl-dev \
 	pcre-dev \
 	git \
 	sqlite

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Flask==2.2.2
 Flask-Cors==3.0.10
 pytest==7.2.0
 connexion==2.14.1
-uwsgi==2.0.21
+uwsgi==2.0.23
 swagger-ui-bundle==0.0.9


### PR DESCRIPTION
Only uwsgi needed to be updated; this also picks up the removal of libressl-dev from https://github.com/CanDIG/query/pull/8.

I don't think query has any automated tests...?