### PR TITLE
Fix for the search page on query

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -303,7 +303,7 @@ def genomic_completeness():
     r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params)}",
         # Reuse their bearer token
         headers=request.headers), 'Katsu sample registrations')
-    samples = r['results']
+    samples = r['items']
 
     retVal = {}
     for sample in samples:


### PR DESCRIPTION
# Description
There's an outstanding bug on the search page from the UUID switch that #6 did not fix. I've been changing this one locally everywhere before realizing I should just make a PR for it. This fixes the the query microservice call on the search page.