### PR TITLE
add libffi-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apk add --no-cache \
 	yaml-dev \
 	pcre-dev \
 	git \
-	sqlite
+	sqlite \
+ 	libffi-dev
 
 COPY requirements.txt /app/query_server/requirements.txt
 


### PR DESCRIPTION
When trying to use the latest develop version of query I ran into an error where the python depdendency `cffi` would not install.

After some googling found that adding the `libffi-dev` dependency when the container is built could help. [Stack Overflow post](https://stackoverflow.com/questions/38109637/package-libffi-was-not-found-in-the-pkg-config-search-path-redhat6-5) 

This fixed the issue for me. Query builds and starts successfully and integration tests pass when running locally.