### PR TITLE
DIG-1447: Fix the miscount on donors contributing to age summary stats once per treatment

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -65,35 +65,39 @@ def get_summary_stats(donors, headers):
     for donor in donors:
         donor_date_of_births[donor['submitter_donor_id']] = donor['date_of_birth']
     age_at_diagnosis = {}
+    known_donors = {}
     for diagnosis in diagnoses:
         if diagnosis['submitter_donor_id'] in donor_date_of_births:
-            # Make sure we have both dates necessary for this analysis
-            if 'date_of_diagnosis' not in diagnosis or diagnosis['date_of_diagnosis'] is None:
-                print(f"Unable to find diagnosis date for {diagnosis['submitter_donor_id']}")
-                add_or_increment(age_at_diagnosis, 'Unknown')
-                continue
-            if diagnosis['submitter_donor_id'] not in donor_date_of_births or donor_date_of_births[diagnosis['submitter_donor_id']] is None:
-                print(f"Unable to find date of birth for {diagnosis['submitter_donor_id']}")
-                add_or_increment(age_at_diagnosis, 'Unknown')
-                continue
+            if diagnosis['submitter_donor_id'] not in known_donors.keys():
+                known_donors[diagnosis['submitter_donor_id']] = diagnosis
+    for diagnosis in known_donors.values():
+        # Make sure we have both dates necessary for this analysis
+        if 'date_of_diagnosis' not in diagnosis or diagnosis['date_of_diagnosis'] is None:
+            print(f"Unable to find diagnosis date for {diagnosis['submitter_donor_id']}")
+            add_or_increment(age_at_diagnosis, 'Unknown')
+            continue
+        if diagnosis['submitter_donor_id'] not in donor_date_of_births or donor_date_of_births[diagnosis['submitter_donor_id']] is None:
+            print(f"Unable to find date of birth for {diagnosis['submitter_donor_id']}")
+            add_or_increment(age_at_diagnosis, 'Unknown')
+            continue
 
-            diag_date = diagnosis['date_of_diagnosis'].split('-')
-            birth_date = donor_date_of_births[diagnosis['submitter_donor_id']].split('-')
-            if len(diag_date) < 2 or len(birth_date) < 2:
-                print(f"Unable to find date of birth/diagnosis for {diagnosis['submitter_donor_id']}")
-                add_or_increment(age_at_diagnosis, 'Unknown')
-                continue
+        diag_date = diagnosis['date_of_diagnosis'].split('-')
+        birth_date = donor_date_of_births[diagnosis['submitter_donor_id']].split('-')
+        if len(diag_date) < 2 or len(birth_date) < 2:
+            print(f"Unable to find date of birth/diagnosis for {diagnosis['submitter_donor_id']}")
+            add_or_increment(age_at_diagnosis, 'Unknown')
+            continue
 
-            age = int(diag_date[0]) - int(birth_date[0])
-            if int(diag_date[1]) >= int(birth_date[1]):
-                age += 1
-            age = age // 10 * 10
-            if age < 20:
-                add_or_increment(age_at_diagnosis, '0-19 Years')
-            elif age > 79:
-                add_or_increment(age_at_diagnosis, '80+ Years')
-            else:
-                add_or_increment(age_at_diagnosis, f'{age}-{age+9} Years')
+        age = int(diag_date[0]) - int(birth_date[0])
+        if int(diag_date[1]) >= int(birth_date[1]):
+            age += 1
+        age = age // 10 * 10
+        if age < 20:
+            add_or_increment(age_at_diagnosis, '0-19 Years')
+        elif age > 79:
+            add_or_increment(age_at_diagnosis, '80+ Years')
+        else:
+            add_or_increment(age_at_diagnosis, f'{age}-{age+9} Years')
 
     # Treatment types
     # http://candig.docker.internal:8008/v2/authorized/treatments/


### PR DESCRIPTION
# Description

The age_at_diagnosis summary statistic double-counted donors per treatment they had. This PR fixes that.

# To Test

Run the integration tests, then run:

`curl http://candig.docker.internal:5080/query/query?treatment=Chemotherapy -H "Authorization: Bearer $TOKEN"`

Where $TOKEN is a valid auth token. The result should be just one donor, and the "age_at_diagnosis" return should only have a count of 1 instead of 2.
