### PR TITLE
Genomic search fix

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -292,7 +292,6 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
         for i, donor_id in enumerate(ret_donors):
             donor_id_url = urllib.parse.quote(donor_id)
             program_id_url = urllib.parse.quote(ret_programs[i])
-            print('asdf')
             r = requests.get(f"{config.KATSU_URL}/v2/authorized/donor_with_clinical_data/program/{program_id_url}/donor/{donor_id_url}",
                 headers=headers)
             full_data['results'].append(safe_get_request_json(r, 'Katsu donor clinical data'))

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -241,11 +241,11 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
             specimen_query_req = requests.get(f"{config.KATSU_URL}/v2/authorized/sample_registrations/?page_size=10000000", headers=headers)
             specimen_query = safe_get_request_json(specimen_query_req, 'Katsu sample registrations')
             specimen_mapping = {}
-            for specimen in specimen_query['results']:
+            for specimen in specimen_query['items']:
                 specimen_mapping[specimen['submitter_sample_id']] = (specimen['submitter_donor_id'], specimen['tumour_normal_designation'])
 
             # handovers = htsget['results']['beaconHandovers']
-            genomic_query_info = htsget['results']['query_info']
+            genomic_query_info = htsget['query_info']
             for cohort in genomic_query_info:
                sample_ids = genomic_query_info[cohort]
                print(f"cohort {cohort} has samples {sample_ids}")


### PR DESCRIPTION
# Description

Unsure how this worked before, but the genomic search appears to be looking in the wrong location for a few values. This PR also removes a debugging statement I found.

# To Test

Run the integration tests, then run:

`curl http://candig.docker.internal:5080/query/query?chrom=chr21:5030000-5030847&assembly=hg37 -H "Authorization: Bearer $TOKEN"`

Where $TOKEN is a valid auth token. The result should include genomic_search results.
