### PR TITLE
Add clinical discovery queries

### DIFF
--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -216,10 +216,15 @@ components:
                     type: object
                     description: Summary statistics of program id (key) to another object with number of complete genomic and transcriptome cases
         DiscoveryProgramBody:
-            type: array
-            description: Genomic completeness statistics
-            items:
-                type: object
+            type: object
+            description: Discovery programs
+            properties:
+                site:
+                    type: object
+                    description: Whole-site summary statistics
+                programs:
+                    type: array
+                    description: Per-program summary statistics
         # ERROR SCHEMAS
         Error:
             type: object

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -60,11 +60,25 @@ paths:
             operationId: query_operations.genomic_completeness
             responses:
                 200:
-                    description: Retrieved genomic completness information
+                    description: Retrieved genomic completeness information
                     content:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/GenomicCompletenessBody'
+                5XX:
+                    $ref: "#/components/responses/5xxServerError"
+    /discovery/programs:
+        get:
+            summary: Retrieve summary statistics on the metadata for each program, as well as the current site.
+            description: Retrieve summary statistics on the metadata for each program, as well as the current site.
+            operationId: query_operations.discovery_programs
+            responses:
+                200:
+                    description: Summary statistics
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/DiscoveryProgramBody'
                 5XX:
                     $ref: "#/components/responses/5xxServerError"
                     
@@ -201,6 +215,11 @@ components:
                 results:
                     type: object
                     description: Summary statistics of program id (key) to another object with number of complete genomic and transcriptome cases
+        DiscoveryProgramBody:
+            type: array
+            description: Genomic completeness statistics
+            items:
+                type: object
         # ERROR SCHEMAS
         Error:
             type: object

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -1,5 +1,5 @@
-from flask import request, Flask, session
-import json
+from flask import request, Flask
+import copy
 import re
 import requests
 import secrets
@@ -314,4 +314,57 @@ def genomic_completeness():
                 retVal[program_id]['transcriptomes'] += 1
 
     return retVal, 200
+
+@app.route('/discovery/programs')
+def discovery_programs():
+    # Grab all programs from Katsu
+    url = f"{config.KATSU_URL}/v2/discovery/programs/"
+    r = safe_get_request_json(requests.get(url), 'Katsu sample registrations')
+
+    # Aggregate all of the programs' return values into one value for the entire site
+    site_summary_stats = {
+        'schemas_used': set(),
+        'schemas_not_used': set(),
+        'required_but_missing': {}
+    }
+    unused_schemas = set()
+    unused_initialized = False
+    for program in r:
+        if 'metadata' not in program:
+            print(f"Strange result from Katsu: no metadata in {program}")
+            continue
+        metadata = program['metadata']
+
+        # There's five metadata categories we care about:
+        # schemas_used is a set, schemas_not_used is the inverse of that set
+        if not unused_initialized:
+            unused_initialized = True
+            unused_schemas = set(metadata['schemas_not_used'])
+        site_summary_stats['schemas_used'] |= set(metadata['schemas_used'])
+
+        required_but_missing = metadata['required_but_missing']
+        for field in required_but_missing:
+            # Assuming these are of the form 'treatment_setting': {'total': 1, 'missing': 0}
+            if field in site_summary_stats['required_but_missing']:
+                for category in required_but_missing[field]:
+                    if category in site_summary_stats['required_but_missing'][field]:
+                        for instance in required_but_missing[field][category]:
+                            site_summary_stats['required_but_missing'][field][category][instance] += required_but_missing[field][category][instance]
+                    else:
+                        site_summary_stats['required_but_missing'][field][category] = copy.deepcopy(required_but_missing[field][category])
+            else:
+                site_summary_stats['required_but_missing'][field] = copy.deepcopy(required_but_missing[field])
+
+    for schema in site_summary_stats['schemas_used']:
+        unused_schemas.discard(schema)
+    site_summary_stats['schemas_not_used'] = list(unused_schemas)
+    site_summary_stats['schemas_used'] = list(site_summary_stats['schemas_used'])
+
+    # Return both the site's aggregated return value and each individual programs'
+    ret_val = {
+        'site': site_summary_stats,
+        'programs': r
+    }
+
+    return ret_val, 200
 

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -325,7 +325,8 @@ def discovery_programs():
     site_summary_stats = {
         'schemas_used': set(),
         'schemas_not_used': set(),
-        'required_but_missing': {}
+        'required_but_missing': {},
+        'cases_missing_data': set()
     }
     unused_schemas = set()
     unused_initialized = False
@@ -341,6 +342,7 @@ def discovery_programs():
             unused_initialized = True
             unused_schemas = set(metadata['schemas_not_used'])
         site_summary_stats['schemas_used'] |= set(metadata['schemas_used'])
+        site_summary_stats['cases_missing_data'] |= set(metadata['cases_missing_data'])
 
         required_but_missing = metadata['required_but_missing']
         for field in required_but_missing:
@@ -359,6 +361,7 @@ def discovery_programs():
         unused_schemas.discard(schema)
     site_summary_stats['schemas_not_used'] = list(unused_schemas)
     site_summary_stats['schemas_used'] = list(site_summary_stats['schemas_used'])
+    site_summary_stats['cases_missing_data'] = list(site_summary_stats['cases_missing_data'])
 
     # Return both the site's aggregated return value and each individual programs'
     ret_val = {


### PR DESCRIPTION
- Add support for clinical discovery queries
- Integration tests are [here](https://github.com/CanDIG/CanDIGv2/pull/446)
- Access them manually via `curl candig.docker.internal:1236/discovery/programs/` after running integration tests