### PR TITLE
Bump versions to fix Snyk vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pytest==7.2.0
 connexion==2.14.2
 uwsgi==2.0.23
 swagger-ui-bundle==0.0.9
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.0
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Flask==2.2.2
+Flask==2.2.5
 Flask-Cors==3.0.10
 pytest==7.2.0
-connexion==2.14.1
+connexion==2.14.2
 uwsgi==2.0.23
 swagger-ui-bundle==0.0.9
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.0


### PR DESCRIPTION
# Description
Bumps the version of two of the requirements to due to vulnerabilties found by Snyk. See #3 for details (the only two from that one that are still valid are the [Information Exposure](https://snyk.io/vuln/SNYK-PYTHON-FLASK-5490129) and [Inefficient Algorithmic Complexity](https://snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6035177) warnings.