### PR TITLE
DIG-1527: Catch error when treatment_type is null

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -95,8 +95,12 @@ def get_summary_stats(donors, headers):
     treatment_type_count = {}
     for treatment in treatments:
         if treatment["submitter_donor_id"] in donors_by_id:
-            for treatment_type in treatment["treatment_type"]:
-                add_or_increment(treatment_type_count, treatment_type)
+            try:
+                for treatment_type in treatment["treatment_type"]:
+                    add_or_increment(treatment_type_count, treatment_type)
+            except TypeError as e:
+                print(e)
+                pass
 
     return {
         'age_at_diagnosis': age_at_diagnosis,


### PR DESCRIPTION
If a program has data where `treatment.treatment_type` was null, query throws an error and causes the program not to appear in the data portal. This change catches the error and passes since if it is not present, we don't need to count it. Not sure if we should print the error message or this is fine.
