### PR TITLE
Extend timeout for queries to be 60s

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -9,4 +9,4 @@ processes = 4
 gid = candig
 uid = candig
 
-harakiri = 30
+harakiri = 60


### PR DESCRIPTION
This is a temporary measure while we roll out performance enhancements.