### PR TITLE
DIG-1597: primary site query fix

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -180,9 +180,10 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     params = { 'page_size': PAGE_SIZE }
     url = f"{config.KATSU_URL}/v2/authorized/donors/"
     if primary_site != "" and len(primary_site) > 1:
-        params['primary_site'] = "&primary_site=".join(primary_site)
-    print(f"{url}?primary_site={urllib.parse.urlencode(params)}")
-    r = safe_get_request_json(requests.get(f"{url}?primary_site={urllib.parse.urlencode(params)}",
+        params['primary_site'] = [urllib.parse.quote(x) for x in params['primary_site']]
+        params['primary_site'] = "&primary_site=".join(params['primary_site'])
+    print(f"{url}?primary_site={params}")
+    r = safe_get_request_json(requests.get(f"{url}?primary_site={params}",
         # Reuse their bearer token
         headers=headers), 'Katsu Donors')
     donors = r['items']

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -180,16 +180,10 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     params = { 'page_size': PAGE_SIZE }
     url = f"{config.KATSU_URL}/v2/authorized/donors/"
     if primary_site != "":
-        primary_site_params = [("primary_site", x) for x in primary_site]
-        print(f"{url}?{urllib.parse.urlencode(params)}&{urllib.parse.urlencode(primary_site_params)}")
-        r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params)}&"
-                                               f"{urllib.parse.urlencode(primary_site_params)}",
-                                               # Reuse their bearer token
-                                               headers=headers), 'Katsu Donors')
-    else:
-        r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params)}",
-                                               # Reuse their bearer token
-                                               headers=headers), 'Katsu Donors')
+        params['primary_site'] = primary_site
+    r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params, True)}",
+        # Reuse their bearer token
+        headers=headers), 'Katsu Donors')
     donors = r['items']
 
     # Filter on excluded cohorts

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -181,7 +181,7 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     url = f"{config.KATSU_URL}/v2/authorized/donors/"
     if primary_site != "" and len(primary_site) > 1:
         params['primary_site'] = "&primary_site=".join(primary_site)
-    print(f"{url}?{urllib.parse.urlencode(params)}")
+    print(f"{url}?primary_site={urllib.parse.urlencode(params)}")
     r = safe_get_request_json(requests.get(f"{url}?primary_site={urllib.parse.urlencode(params)}",
         # Reuse their bearer token
         headers=headers), 'Katsu Donors')

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -181,11 +181,15 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     url = f"{config.KATSU_URL}/v2/authorized/donors/"
     if primary_site != "":
         primary_site_params = [("primary_site", x) for x in primary_site]
-    print(f"{url}?{urllib.parse.urlencode(params)}&{urllib.parse.urlencode(primary_site_params)}")
-    r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params['page_size'])}&"
-                                           f"{urllib.parse.urlencode(primary_site_params)}",
-        # Reuse their bearer token
-        headers=headers), 'Katsu Donors')
+        print(f"{url}?{urllib.parse.urlencode(params)}&{urllib.parse.urlencode(primary_site_params)}")
+        r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params)}&"
+                                               f"{urllib.parse.urlencode(primary_site_params)}",
+                                               # Reuse their bearer token
+                                               headers=headers), 'Katsu Donors')
+    else:
+        r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params)}",
+                                               # Reuse their bearer token
+                                               headers=headers), 'Katsu Donors')
     donors = r['items']
 
     # Filter on excluded cohorts

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -179,11 +179,11 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     # Query the appropriate Katsu endpoint
     params = { 'page_size': PAGE_SIZE }
     url = f"{config.KATSU_URL}/v2/authorized/donors/"
-    if primary_site != "" and len(primary_site) > 1:
-        params['primary_site'] = [urllib.parse.quote(x) for x in params['primary_site']]
-        params['primary_site'] = "&primary_site=".join(params['primary_site'])
-    print(f"{url}?primary_site={params}")
-    r = safe_get_request_json(requests.get(f"{url}?primary_site={params}",
+    if primary_site != "":
+        primary_site_params = [("primary_site", x) for x in primary_site]
+    print(f"{url}?{urllib.parse.urlencode(params)}&{urllib.parse.urlencode(primary_site_params)}")
+    r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params['page_size'])}&"
+                                           f"{urllib.parse.urlencode(params['primary_site'])}",
         # Reuse their bearer token
         headers=headers), 'Katsu Donors')
     donors = r['items']

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -179,9 +179,10 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     # Query the appropriate Katsu endpoint
     params = { 'page_size': PAGE_SIZE }
     url = f"{config.KATSU_URL}/v2/authorized/donors/"
-    if primary_site != "":
-        params['primary_site'] = ",".join(primary_site)
-    r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params)}",
+    if primary_site != "" and len(primary_site) > 1:
+        params['primary_site'] = "&primary_site=".join(primary_site)
+    print(f"{url}?{urllib.parse.urlencode(params)}")
+    r = safe_get_request_json(requests.get(f"{url}?primary_site={urllib.parse.urlencode(params)}",
         # Reuse their bearer token
         headers=headers), 'Katsu Donors')
     donors = r['items']

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -183,7 +183,7 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
         primary_site_params = [("primary_site", x) for x in primary_site]
     print(f"{url}?{urllib.parse.urlencode(params)}&{urllib.parse.urlencode(primary_site_params)}")
     r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params['page_size'])}&"
-                                           f"{urllib.parse.urlencode(params['primary_site'])}",
+                                           f"{urllib.parse.urlencode(primary_site_params)}",
         # Reuse their bearer token
         headers=headers), 'Katsu Donors')
     donors = r['items']


### PR DESCRIPTION
Queries with multiple primary sites were not working due to the list being passed to katsu as a comma delimited string instead of `primary_site=eye&primary_site=brain` etc.

This PR properly parses the list and gives it to katsu in a way that it understands. I did this with an if,else because the urllib.parse.urlencode can only deal with either a dict to do simple key value parsing, or a list of tuples , which we need in this case to get the repeating variable. If you can think of a nicer way to do it though then feel free to change.

To test:
- checkout this branch in your CanDIGv2 stack
- select one primary site, eg. eye and adnexa, one donor should be returned
- select a second primary site, e.g. floor of mouth, a second donor should show up in the clinical data table