### PR TITLE
DIG-1616: Stop using donor-with-clinical-data endpoint for clinical data table 

### DIFF
--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -111,40 +111,45 @@ components:
         treatmentParam:
             in: query
             name: treatment
-            description: A comma-separated list of treatments to look for
-            example: Bone marrow transplant,Chemotherapy
+            style: pipeDelimited
+            description: A pipe-separated list of treatments to look for
+            example: Bone marrow transplant|Chemotherapy
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
         primarySiteParam:
             in: query
             name: primary_site
-            description: A comma-separated list of affected primary sites to look for
-            example: Adrenal gland,Bladder
+            style: pipeDelimited
+            description: A pipe-separated list of affected primary sites to look for
+            example: Adrenal gland|Bladder
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
         chemotherapyParam:
             in: query
             name: chemotherapy
-            description: A comma-separated list of chemotherapy treatments to look for
-            example: FLUOROURACIL,LEUCOVORIN
+            style: pipeDelimited
+            description: A pipe-separated list of chemotherapy treatments to look for
+            example: FLUOROURACIL|LEUCOVORIN
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
         immunotherapyParam:
             in: query
             name: immunotherapy
-            description: A comma-separated list of immunotherapy treatments to look for
-            example: Necitumumab,Pembrolizumab
+            style: pipeDelimited
+            description: A pipe-separated list of immunotherapy treatments to look for
+            example: Necitumumab|Pembrolizumab
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
         hormoneTherapyParam:
             in: query
             name: hormone_therapy
-            description: A comma-separated list of hormone therapy treatments to look for
-            example: Goserelin,Leuprolide
+            style: pipeDelimited
+            description: A pipe-separated list of hormone therapy treatments to look for
+            example: Goserelin|Leuprolide
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -280,23 +280,12 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     summary_stats = get_summary_stats(donors, headers)
 
     # Determine which part of the filtered donors to send back
-    ret_donors = [donor['submitter_donor_id'] for donor in donors[(page*page_size):((page+1)*page_size)]]
-    ret_programs = [donor['program_id'] for donor in donors[(page*page_size):((page+1)*page_size)]]
-    full_data = {'results' : []}
-    if len(donors) > 0:
-        for i, donor_id in enumerate(ret_donors):
-            donor_id_url = urllib.parse.quote(donor_id)
-            program_id_url = urllib.parse.quote(ret_programs[i])
-            r = requests.get(f"{config.KATSU_URL}/v2/authorized/donor_with_clinical_data/program/{program_id_url}/donor/{donor_id_url}",
-                headers=headers)
-            full_data['results'].append(safe_get_request_json(r, 'Katsu donor clinical data'))
-    else:
-        full_data = {'results': []}
-    full_data['genomic'] = genomic_query
-    full_data['count'] = len(donors)
-    full_data['summary'] = summary_stats
-    full_data['next'] = None
-    full_data['prev'] = None
+    full_data = {
+        'results': [donor for donor in donors[(page*page_size):((page+1)*page_size)]],
+        'genomic': genomic_query,
+        'count': len(donors),
+        'summary': summary_stats
+    }
     # full_data['genomic_query_info'] = genomic_query_info
 
     # Add prev and next parameters to the repsonse, appending a session ID.

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -409,7 +409,7 @@ def discovery_programs():
         'programs': r
     }
 
-    return ret_val, 200
+    return fix_dicts(ret_val), 200
 
 @app.route('/discovery/query')
 def discovery_query(treatment="", primary_site="", chemotherapy="", immunotherapy="", hormone_therapy="", chrom="", gene="", assembly="hg38", exclude_cohorts=[]):
@@ -485,5 +485,4 @@ def discovery_query(treatment="", primary_site="", chemotherapy="", immunotherap
                     add_or_increment(summary_stats[mapping[0]], item)
             else:
                 add_or_increment(summary_stats[mapping[0]], donor[mapping[1]])
-
-    return summary_stats, 200
+    return fix_dicts(summary_stats), 200

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -276,7 +276,7 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
                         genomic_query.append(case_data)
 
         except Exception as ex:
-            print(ex)
+            print(f"Error while reading HTSGet response: {ex}")
 
     # TODO: Cache the above list of donor IDs and summary statistics
     summary_stats = get_summary_stats(donors, headers)

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -94,12 +94,14 @@ def get_summary_stats(donors, headers):
     treatments = safe_get_request_json(treatments, 'Katsu treatments')['items']
     treatment_type_count = {}
     for treatment in treatments:
-        if treatment["submitter_donor_id"] in donors_by_id:
+        if (treatment["submitter_donor_id"] in donors_by_id and
+            "treatment_type" in treatment and
+            treatment["treatment_type"] is not None):
             try:
                 for treatment_type in treatment["treatment_type"]:
                     add_or_increment(treatment_type_count, treatment_type)
             except TypeError as e:
-                print(e)
+                print(f"Could not grab summary treatment stats: {e}")
                 pass
 
     return {


### PR DESCRIPTION
# Description
This PR speeds up the query endpoint massively by removing the return of the donor-with-clinical-data search during querying to populate the Clinical Data table, as that table is no longer reliant on data that required that endpoint.

# To test
Install this onto Query, load up a medium sized dataset (ie. from the mohccn repo), and check the load times -- I was getting 120ms as opposed to the 2.5s from before.

# Tickets
[DIG-1616](https://candig.atlassian.net/browse/DIG-1616)

[DIG-1616]: https://candig.atlassian.net/browse/DIG-1616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ