### PR TITLE
Allow parameters with commas by switching the internal splitter to pipe-delimiters

### DIFF
--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -111,40 +111,45 @@ components:
         treatmentParam:
             in: query
             name: treatment
-            description: A comma-separated list of treatments to look for
-            example: Bone marrow transplant,Chemotherapy
+            style: pipeDelimited
+            description: A pipe-separated list of treatments to look for
+            example: Bone marrow transplant|Chemotherapy
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
         primarySiteParam:
             in: query
             name: primary_site
-            description: A comma-separated list of affected primary sites to look for
-            example: Adrenal gland,Bladder
+            style: pipeDelimited
+            description: A pipe-separated list of affected primary sites to look for
+            example: Adrenal gland|Bladder
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
         chemotherapyParam:
             in: query
             name: chemotherapy
-            description: A comma-separated list of chemotherapy treatments to look for
-            example: FLUOROURACIL,LEUCOVORIN
+            style: pipeDelimited
+            description: A pipe-separated list of chemotherapy treatments to look for
+            example: FLUOROURACIL|LEUCOVORIN
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
         immunotherapyParam:
             in: query
             name: immunotherapy
-            description: A comma-separated list of immunotherapy treatments to look for
-            example: Necitumumab,Pembrolizumab
+            style: pipeDelimited
+            description: A pipe-separated list of immunotherapy treatments to look for
+            example: Necitumumab|Pembrolizumab
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
         hormoneTherapyParam:
             in: query
             name: hormone_therapy
-            description: A comma-separated list of hormone therapy treatments to look for
-            example: Goserelin,Leuprolide
+            style: pipeDelimited
+            description: A pipe-separated list of hormone therapy treatments to look for
+            example: Goserelin|Leuprolide
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'


### PR DESCRIPTION
# Description
The discovery queries highlighted a problem, which is that searching for certain primary sites that have commas in the name (e.g. `Heart, mediastinum, and pleura`) would not get passed along to Katsu properly, as it was getting split by connexion.

# To test
Running integration tests with `KEEP_TEST_DATA=true` and searching for the TEST_2 donor by filtering on primary site `Heart, mediastinum, and pleura` should work.