### PR TITLE
DIG-1609: Fix an issue where having no response from HTSGet was treated as having all donors match

### DIFF
--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -177,6 +177,7 @@ components:
             example: hg38
             schema:
                 $ref: '#/components/schemas/Field'
+                default: hg38
         excludeCohortsParam:
             in: query
             name: exclude_cohorts

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -280,6 +280,8 @@ def query(treatment=[], primary_site=[], chemotherapy=[], immunotherapy=[], horm
                 donors = []
 
         except Exception as ex:
+            # Treat a Genomic Search with no valid response from HTSGet as an empty response
+            donors = []
             print(f"Error while reading HTSGet response: {ex}")
 
     # TODO: Cache the above list of donor IDs and summary statistics


### PR DESCRIPTION
I run into this situation sometimes where searching for a region which has nothing in it will allow all donors through. It should probably be returning zero donors, right?

# To test
1. Load up the integration test data
2. Search up `curl "http://candig.docker.internal:5080/query/query?chrom=chrX:100-10000" -H "Authorization: Bearer $ADMIN_TOKEN"`
3. (Or do the above in the frontend, either or)

## Before this PR:
In the response: 4 donors
In the Query logs: `Error while reading HTSGet response: 'NoneType' object has no attribute 'group'`

## After this PR:
In the response: 0 donors
```
(candig) 13:16 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ curl "http://candig.docker.internal:5080/query/query?chrom=chrX:100-10000" -H "Authorization: Bearer $TOKEN"
{
  "count": 0,
  "genomic": [],
  "results": [],
  "summary": {
    "age_at_diagnosis": {},
    "cancer_type_count": {},
    "patients_per_cohort": {},
    "treatment_type_count": {}
  }
}
```