### PR TITLE
DIG-1533: cancer_type->primary_site & DIG-1583: Implement censoring on aggregate count threshold

### DIFF
--- a/query_server/config.py
+++ b/query_server/config.py
@@ -7,6 +7,7 @@ config.read(os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../c
 
 AUTHZ = config['authz']
 QUERY_URL = os.getenv("QUERY_URL", f"http://localhost:{config['DEFAULT']['Port']}")
+AGGREGATE_COUNT_THRESHOLD = int(os.getenv("AGGREGATE_COUNT_THRESHOLD", "5"))
 
 PORT = config['DEFAULT']['Port']
 

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -58,7 +58,7 @@ def get_summary_stats(donors, headers):
     # Perform (and cache) summary statistics
     age_at_diagnosis = {}
     donors_by_id = {}
-    cancer_type_count = {}
+    primary_site_count = {}
     patients_per_cohort = {}
     for donor in donors:
         # A donor's date of birth is defined as the (negative) interval between actual DOB and the date of first diagnosis
@@ -77,10 +77,10 @@ def get_summary_stats(donors, headers):
         # Cancer types
         if donor['primary_site']:
             for cancer_type in donor['primary_site']:
-                if cancer_type in cancer_type_count:
-                    cancer_type_count[cancer_type] += 1
+                if cancer_type in primary_site_count:
+                    primary_site_count[cancer_type] += 1
                 else:
-                    cancer_type_count[cancer_type] = 1
+                    primary_site_count[cancer_type] = 1
         program_id = donor['program_id']
         if program_id in patients_per_cohort:
             patients_per_cohort[program_id] += 1
@@ -107,7 +107,7 @@ def get_summary_stats(donors, headers):
     return {
         'age_at_diagnosis': age_at_diagnosis,
         'treatment_type_count': treatment_type_count,
-        'cancer_type_count': cancer_type_count,
+        'primary_site_count': primary_site_count,
         'patients_per_cohort': patients_per_cohort
     }
 
@@ -453,14 +453,14 @@ def discovery_query(treatment="", primary_site="", chemotherapy="", immunotherap
     summary_stats = {
         'age_at_diagnosis': {},
         'treatment_type_count': {},
-        'cancer_type_count': {},
+        'primary_site_count': {},
         'patients_per_cohort': {}
     }
     summary_stat_mapping = [
         ('age_at_diagnosis', 'age_at_diagnosis'),
         ('treatment_type_count', 'treatment_type'),
         ('patients_per_cohort', 'program_id'),
-        ('cancer_type_count', 'primary_site')
+        ('primary_site_count', 'primary_site')
     ]
     for donor in donors:
         for mapping in summary_stat_mapping:

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -335,8 +335,6 @@ def genomic_completeness():
         if len(sample['transcriptomes']) > 0:
             retVal[program_id]['transcriptomes'] += 1
 
-    retVal = censor_response(retVal)
-
     return retVal, 200
 
 @app.route('/discovery/programs')
@@ -404,9 +402,6 @@ def discovery_programs():
     site_summary_stats['schemas_not_used'] = list(unused_schemas)
     site_summary_stats['schemas_used'] = list(site_summary_stats['schemas_used'])
     site_summary_stats['cases_missing_data'] = list(site_summary_stats['cases_missing_data'])
-
-    site_summary_stats = censor_response(site_summary_stats)
-    r = censor_response(r)
 
     # Return both the site's aggregated return value and each individual programs'
     ret_val = {

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -469,4 +469,10 @@ def discovery_query(treatment="", primary_site="", chemotherapy="", immunotherap
                     add_or_increment(summary_stats[mapping[0]], item)
             else:
                 add_or_increment(summary_stats[mapping[0]], donor[mapping[1]])
+
+    # Censor if necessary
+    for stat in summary_stats:
+        if summary_stats[stat] < config.AGGREGATE_COUNT_THRESHOLD:
+            summary_stats[stat] = "<" + config.AGGREGATE_COUNT_THRESHOLD
+
     return fix_dicts(summary_stats), 200


### PR DESCRIPTION
# Best tested from CanDIGv2's `feature/censoring-and-rename-cancer-type` branch

# Description
Includes #37 because it is required to handle the new version of [Katsu](https://github.com/CanDIG/katsu/pull/205)

This both handles data censoring on discovery queries for low counts, and renaming cancer_type to primary_site.

## To test:
- `curl candig.docker.internal:5080/query/discovery/programs -H "Authorization: Bearer $TOKEN"`
- `curl candig.docker.internal:5080/query/genomic_completeness -H "Authorization: Bearer $TOKEN"`
- `curl candig.docker.internal:5080/query/discovery/query -H "Authorization: Bearer $TOKEN"`