### PR TITLE
DIG-1686: Update query to work with updated katsu endpoints

### DIFF
--- a/query_server/config.py
+++ b/query_server/config.py
@@ -21,6 +21,8 @@ if os.getenv("DEBUG_MODE", "1") == "1":
 
 try:
     SERVICE_TOKEN = create_service_token()
+    if DEBUG_MODE:
+        print(f"SERVICE_TOKEN: {SERVICE_TOKEN}")
 except:
     print("Could not obtain a service token")
     SERVICE_TOKEN = ""

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -194,6 +194,7 @@ components:
         excludeCohortsParam:
             in: query
             name: exclude_cohorts
+            style: pipeDelimited
             description: A list of cohorts that will be excluded from results
             example: SYNTHETIC-1
             schema:

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -77,13 +77,13 @@ def get_summary_stats(donors, headers):
             else:
                 add_or_increment(age_at_diagnosis, f'{age}-{age+9} Years')
 
-        # Cancer types
-        if donor['primary_site']:
-            for cancer_type in donor['primary_site']:
-                if cancer_type in primary_site_count:
-                    primary_site_count[cancer_type] += 1
-                else:
-                    primary_site_count[cancer_type] = 1
+        # primary sites
+        for primary_diagnosis in donor['primary_diagnosis']:
+            primary_site = primary_diagnosis['primary_site']
+            if primary_site in primary_site_count:
+                primary_site_count[primary_site] += 1
+            else:
+                primary_site_count[primary_site] = 1
         program_id = donor['program_id']
         if program_id in patients_per_cohort:
             patients_per_cohort[program_id] += 1
@@ -208,8 +208,6 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
     # Query the appropriate Katsu endpoint
     params = { 'page_size': PAGE_SIZE }
     url = f"{config.KATSU_URL}/v2/authorized/donors/"
-    if primary_site != "":
-        params['primary_site'] = primary_site
     r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params, True)}",
         # Reuse their bearer token
         headers=headers), 'Katsu Donors')
@@ -223,7 +221,8 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
         (treatment, f"{config.KATSU_URL}/v2/authorized/treatments/", 'treatment_type', None),
         (chemotherapy, f"{config.KATSU_URL}/v2/authorized/systemic_therapies/", 'drug_name', 'chemotherapy'),
         (immunotherapy, f"{config.KATSU_URL}/v2/authorized/systemic_therapies/", 'drug_name', 'immunotherapy'),
-        (hormone_therapy, f"{config.KATSU_URL}/v2/authorized/systemic_therapies/", 'drug_name', 'hormone therapy')
+        (hormone_therapy, f"{config.KATSU_URL}/v2/authorized/systemic_therapies/", 'drug_name', 'hormone therapy'),
+        (primary_site, f"{config.KATSU_URL}/v2/authorized/primary_diagnoses/", 'primary_site', None),
     ]
     for (this_filter, url, param_name, therapy_type) in filters:
         if this_filter != "":

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -91,8 +91,8 @@ def get_summary_stats(donors, headers):
             patients_per_cohort[program_id] = 1
 
     # Treatment types
-    # http://candig.docker.internal:8008/v2/authorized/treatments/
-    treatments = requests.get(f"{config.KATSU_URL}/v2/authorized/treatments/?page_size={PAGE_SIZE}",
+    # http://candig.docker.internal:8008/v3/authorized/treatments/
+    treatments = requests.get(f"{config.KATSU_URL}/v3/authorized/treatments/?page_size={PAGE_SIZE}",
         headers=headers)
     treatments = safe_get_request_json(treatments, 'Katsu treatments')['items']
     treatment_type_count = {}
@@ -207,7 +207,7 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
 
     # Query the appropriate Katsu endpoint
     params = { 'page_size': PAGE_SIZE }
-    url = f"{config.KATSU_URL}/v2/authorized/donors/"
+    url = f"{config.KATSU_URL}/v3/authorized/donors/"
     r = safe_get_request_json(requests.get(f"{url}?{urllib.parse.urlencode(params, True)}",
         # Reuse their bearer token
         headers=headers), 'Katsu Donors')
@@ -218,11 +218,11 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
 
     # Will need to look into how to go about this -- ideally we implement this into the SQL in Katsu's side
     filters = [
-        (treatment, f"{config.KATSU_URL}/v2/authorized/treatments/", 'treatment_type', None),
-        (chemotherapy, f"{config.KATSU_URL}/v2/authorized/systemic_therapies/", 'drug_name', 'chemotherapy'),
-        (immunotherapy, f"{config.KATSU_URL}/v2/authorized/systemic_therapies/", 'drug_name', 'immunotherapy'),
-        (hormone_therapy, f"{config.KATSU_URL}/v2/authorized/systemic_therapies/", 'drug_name', 'hormone therapy'),
-        (primary_site, f"{config.KATSU_URL}/v2/authorized/primary_diagnoses/", 'primary_site', None),
+        (treatment, f"{config.KATSU_URL}/v3/authorized/treatments/", 'treatment_type', None),
+        (chemotherapy, f"{config.KATSU_URL}/v3/authorized/systemic_therapies/", 'drug_name', 'chemotherapy'),
+        (immunotherapy, f"{config.KATSU_URL}/v3/authorized/systemic_therapies/", 'drug_name', 'immunotherapy'),
+        (hormone_therapy, f"{config.KATSU_URL}/v3/authorized/systemic_therapies/", 'drug_name', 'hormone therapy'),
+        (primary_site, f"{config.KATSU_URL}/v3/authorized/primary_diagnoses/", 'primary_site', None),
     ]
     for (this_filter, url, param_name, therapy_type) in filters:
         if this_filter != "":
@@ -243,7 +243,7 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
             htsget = query_htsget(headers, gene, assembly, chrom)
 
             # We need to be able to map specimens, so we'll grab it from Katsu
-            specimen_query_req = requests.get(f"{config.KATSU_URL}/v2/authorized/sample_registrations/?page_size=10000000", headers=headers)
+            specimen_query_req = requests.get(f"{config.KATSU_URL}/v3/authorized/sample_registrations/?page_size=10000000", headers=headers)
             specimen_query = safe_get_request_json(specimen_query_req, 'Katsu sample registrations')
             specimen_mapping = {}
             for specimen in specimen_query['items']:
@@ -343,7 +343,7 @@ def genomic_completeness():
 @app.route('/discovery/programs')
 def discovery_programs():
     # Grab all programs from Katsu
-    url = f"{config.KATSU_URL}/v2/discovery/programs/"
+    url = f"{config.KATSU_URL}/v3/discovery/programs/"
     r = safe_get_request_json(requests.get(url), 'Katsu sample registrations')
 
     # Aggregate all of the programs' return values into one value for the entire site
@@ -416,7 +416,7 @@ def discovery_programs():
 
 @app.route('/discovery/query')
 def discovery_query(treatment="", primary_site="", chemotherapy="", immunotherapy="", hormone_therapy="", chrom="", gene="", assembly="hg38", exclude_cohorts=[]):
-    url = f"{config.KATSU_URL}/v2/explorer/donors/"
+    url = f"{config.KATSU_URL}/v3/explorer/donors/"
     headers = {}
     for k in request.headers.keys():
         headers[k] = request.headers[k]


### PR DESCRIPTION
[Jira ticket](https://candig.atlassian.net/browse/DIG-1686)

# Description
This addresses changes from the [Katsu Model 3](https://github.com/CanDIG/katsu/pull/239) PR

# To Test:
1. Check out this branch, CanDIGv2-ingest's `model_3` [branch](https://github.com/CanDIG/candigv2-ingest/compare/develop...model_3), and Katsu's `model_3` [branch](https://github.com/CanDIG/katsu/tree/model_3)
2. Run Katsu ingest with the following:
```
conda activate candig

# Be in the root CanDIG directory for the following
python settings.py
source env.sh
cp env.sh lib/candig-ingest/candigv2-ingest/
cd lib/candig-ingest/candigv2-ingest/

export KATSU_URL=$CANDIG_URL/katsu

export CLINICAL_DATA_LOCATION=/home/fnguyen/Documents/CanDIGv2/lib/candig-ingest/candigv2-ingest/tests/clinical_ingest.json
python katsu_ingest.py
```
3. Modify candig-data-portal with the following: search and replace all instances of `v2/` with `v3/` except for the ones in `package-lock.json`, the Footer's `index.js`, the random line in the `.svg` file, and the ones that are /beacon/v2/g_variants`.
4. Load up the front page