### PR TITLE
Use generic drug names when querying

### DIFF
--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -30,9 +30,7 @@ paths:
             parameters:
                 - $ref: "#/components/parameters/treatmentParam"
                 - $ref: "#/components/parameters/primarySiteParam"
-                - $ref: "#/components/parameters/chemotherapyParam"
-                - $ref: "#/components/parameters/immunotherapyParam"
-                - $ref: "#/components/parameters/hormoneTherapyParam"
+                - $ref: "#/components/parameters/drugNameParam"
                 - $ref: "#/components/parameters/chrParam"
                 - $ref: "#/components/parameters/geneParam"
                 - $ref: "#/components/parameters/assemblyParam"
@@ -89,9 +87,7 @@ paths:
             parameters:
                 - $ref: "#/components/parameters/treatmentParam"
                 - $ref: "#/components/parameters/primarySiteParam"
-                - $ref: "#/components/parameters/chemotherapyParam"
-                - $ref: "#/components/parameters/immunotherapyParam"
-                - $ref: "#/components/parameters/hormoneTherapyParam"
+                - $ref: "#/components/parameters/drugNameParam"
                 - $ref: "#/components/parameters/chrParam"
                 - $ref: "#/components/parameters/geneParam"
                 - $ref: "#/components/parameters/assemblyParam"
@@ -140,30 +136,21 @@ components:
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
-        chemotherapyParam:
+        drugNameParam:
             in: query
-            name: chemotherapy
+            name: drug_name
             style: pipeDelimited
-            description: A pipe-separated list of chemotherapy treatments to look for
+            description: A pipe-separated list of drug names to look for
             example: FLUOROURACIL|LEUCOVORIN
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'
-        immunotherapyParam:
+        systemicTherapyTypeParam:
             in: query
-            name: immunotherapy
+            name: systemic_therapy_type
             style: pipeDelimited
-            description: A pipe-separated list of immunotherapy treatments to look for
-            example: Necitumumab|Pembrolizumab
-            required: false
-            schema:
-                $ref: '#/components/schemas/Fields'
-        hormoneTherapyParam:
-            in: query
-            name: hormone_therapy
-            style: pipeDelimited
-            description: A pipe-separated list of hormone therapy treatments to look for
-            example: Goserelin|Leuprolide
+            description: A pipe-separated list of systemic therapies that we accept
+            example: Chemotherapy|Immunotherapy
             required: false
             schema:
                 $ref: '#/components/schemas/Fields'

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -237,9 +237,9 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
     ]
     if type(systemic_therapy_type) is list:
         for this_type in systemic_therapy_type:
-            filters.add((drug_name, f"{config.KATSU_URL}/v3/authorized/systemic_therapies/", 'drug_name', this_type))
+            filters.append((drug_name, f"{config.KATSU_URL}/v3/authorized/systemic_therapies/", 'drug_name', this_type))
     else:
-        filters.add((drug_name, f"{config.KATSU_URL}/v3/authorized/systemic_therapies/", 'drug_name', None))
+        filters.append((drug_name, f"{config.KATSU_URL}/v3/authorized/systemic_therapies/", 'drug_name', None))
 
     for (this_filter, url, param_name, therapy_type) in filters:
         if this_filter != "":

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -451,7 +451,7 @@ def discovery_query(treatment="", primary_site="", systemic_therapy="", systemic
         (treatment, "treatment_type"),
         (primary_site, "primary_site"),
         (systemic_therapy, "systemic_therapy_drug_name"),
-        (systemic_therapy_type, "systemic_therapy_type")
+        (systemic_therapy_type, "systemic_therapy_type"),
         (exclude_cohorts, "exclude_cohorts")
     ]
     params = {}


### PR DESCRIPTION
Fixes up the query search to work with the systemic therapy drug names, particularly in that the frontend doesn't receive info as to what is a chemo treatment drug vs immunotherapy drug etc. Instead the `/query` and `/discovery/query` endpoints now just take `drug_name` and `systemic_therapy_type`