### PR TITLE
Fixup the counts of the primary sites in the main query call

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -92,18 +92,19 @@ def get_summary_stats(donors, primary_diagnoses, headers):
             else:
                 add_or_increment(age_at_diagnosis, f'{age}-{age+9} Years')
 
-        # primary sites
-        for primary_diagnosis in primary_diagnoses:
-            primary_site = primary_diagnosis['primary_site']
-            if primary_site in primary_site_count:
-                primary_site_count[primary_site] += 1
-            else:
-                primary_site_count[primary_site] = 1
         program_id = donor['program_id']
         if program_id in patients_per_cohort:
             patients_per_cohort[program_id] += 1
         elif program_id is not None:
             patients_per_cohort[program_id] = 1
+
+    # primary sites
+    for primary_diagnosis in primary_diagnoses:
+        primary_site = primary_diagnosis['primary_site']
+        if primary_site in primary_site_count:
+            primary_site_count[primary_site] += 1
+        else:
+            primary_site_count[primary_site] = 1
 
     # Treatment types
     # http://candig.docker.internal:8008/v3/authorized/treatments/
@@ -318,6 +319,10 @@ def query(treatment="", primary_site="", chemotherapy="", immunotherapy="", horm
 
         except Exception as ex:
             print(f"Error while reading HTSGet response: {ex}")
+
+    # We also need to cut down the list of primary diagnoses based on the filtered list of donors at this point
+    permissible_donors = set([donor['submitter_donor_id'] for donor in donors])
+    primary_diagnoses = [primary_diagnosis for primary_diagnosis in primary_diagnoses if primary_diagnosis['submitter_donor_id'] in permissible_donors]
 
     # TODO: Cache the above list of donor IDs and summary statistics
     summary_stats = get_summary_stats(donors, primary_diagnoses, headers)


### PR DESCRIPTION
Fixes a bug where the primary sites were getting multiplied by the number of donors, found by @mshadbolt.

To test: Load up the integration tests, then curl `curl candig.docker.internal:5080/query/query -H "Authorization: Bearer $TOKEN"`. The primary site counts should be accurate to the ingested data.