### PR TITLE
DIG-1803, DIG-1810: query fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Query API for Katsu and HTSGet that allows for caching and pagination of calls.
 
+[openapi spec on Swagger](https://editor.swagger.io/?url=https://raw.githubusercontent.com/CanDIG/query/main/query_server/openapi.yaml)
+
 ## Stack
 
 - [Flask](http://flask.pocoo.org/)

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -224,7 +224,9 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
         (systemic_therapy_type, "systemic_therapy_type"),
         (exclude_cohorts, "exclude_cohorts")
     ]
-    params = {}
+    params = {
+        'page_size': PAGE_SIZE
+    }
     for param in param_mapping:
         if param[0] == "" or param[0] == []:
             continue
@@ -444,7 +446,9 @@ def discovery_query(treatment="", primary_site="", systemic_therapy="", systemic
         (systemic_therapy_type, "systemic_therapy_type"),
         (exclude_cohorts, "exclude_cohorts")
     ]
-    params = {}
+    params = {
+        "page_size": PAGE_SIZE
+    }
     for param in param_mapping:
         if param[0] == "" or param[0] == []:
             continue

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -432,7 +432,7 @@ def discovery_programs():
     return fix_dicts(ret_val), 200
 
 @app.route('/discovery/query')
-def discovery_query(treatment="", primary_site="", systemic_therapy="", systemic_therapy_type="", chrom="", gene="", assembly="hg38", exclude_cohorts=[]):
+def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene="", assembly="hg38", exclude_cohorts=[]):
     url = f"{config.KATSU_URL}/v3/explorer/donors/"
     headers = {}
     for k in request.headers.keys():
@@ -442,8 +442,7 @@ def discovery_query(treatment="", primary_site="", systemic_therapy="", systemic
     param_mapping = [
         (treatment, "treatment_type"),
         (primary_site, "primary_site"),
-        (systemic_therapy, "systemic_therapy_drug_name"),
-        (systemic_therapy_type, "systemic_therapy_type"),
+        (drug_name, "systemic_therapy_drug_name"),
         (exclude_cohorts, "exclude_cohorts")
     ]
     params = {


### PR DESCRIPTION
* Searches should use the default giant page size
* Discovery query needed its parameters updated to latest: add `drug_name` (`systemic_therapy_drug_name`)

I'm pretty sure that `systemic_therapy` and `systemic_therapy_type` are not used for this endpoint, but maybe I'm wrong.