### PR TITLE
Query should handle 401 unauthorized exceptions from Katsu gracefully

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -199,6 +199,22 @@ def fix_dicts(to_fix):
     else:
         return to_fix
 
+# Helper function to format the response from a query into a format the data portal understands
+def format_query_response(donors, genomic_query, summary_stats, page, page_size):
+    # Determine which part of the filtered donors to send back
+    full_data = {
+        'results': donors[(page*page_size):((page+1)*page_size)],
+        'genomic': genomic_query,
+        'count': len(donors),
+        'summary': summary_stats
+    }
+    # full_data['genomic_query_info'] = genomic_query_info
+
+    # Add prev and next parameters to the repsonse, appending a session ID.
+    # Essentially we want to go session ID -> list of donors
+    # and then paginate the list of donors, calling donors_with_clinical_data on each before returning
+    return fix_dicts(full_data), 200
+
 @app.route('/query')
 def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="", chrom="", gene="", page=0, page_size=10, assembly="hg38", exclude_cohorts=[], session_id=""):
     # Add a service token to the headers so that other services will know this is from the query service:
@@ -233,7 +249,17 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
         params[param[1]] = param[0]
 
     full_url = f"{url}?{urllib.parse.urlencode(params, doseq=True)}"
-    donors = safe_get_request_json(requests.get(full_url, headers=headers), 'Katsu explorer donors')['items']
+    donors_req = requests.get(full_url, headers=headers)
+    if not donors_req.ok:
+        if donors_req.status_code == 401:
+            # 401 Unauthorized: the user is not allowed to view any donors at this site
+            # The rest of the code should just pass quietly
+            return format_query_response([], [], get_summary_stats([], {}, {}), page, page_size)
+        else:
+            err_msg = f"Could not got Katsu donors response: {donors_req.status_code} {donors_req.text}"
+            logger.error(err_msg)
+            raise Exception(err_msg)
+    donors = donors_req.json()['items']
 
     # Filter on excluded cohorts
     donors = [donor for donor in donors if donor['program_id'] not in exclude_cohorts]
@@ -317,19 +343,7 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
     # TODO: Cache the above list of donor IDs and summary statistics
     summary_stats = get_summary_stats(donors, summary_info['primary_site'], summary_info['treatment_type'])
 
-    # Determine which part of the filtered donors to send back
-    full_data = {
-        'results': [donor for donor in donors[(page*page_size):((page+1)*page_size)]],
-        'genomic': genomic_query,
-        'count': len(donors),
-        'summary': summary_stats
-    }
-    # full_data['genomic_query_info'] = genomic_query_info
-
-    # Add prev and next parameters to the repsonse, appending a session ID.
-    # Essentially we want to go session ID -> list of donors
-    # and then paginate the list of donors, calling donors_with_clinical_data on each before returning
-    return fix_dicts(full_data), 200
+    return format_query_response(donors, genomic_query, summary_stats, page, page_size)
 
 @app.route('/genomic_completeness')
 def genomic_completeness():


### PR DESCRIPTION
# Jira link
[DIG-1822](https://candig.atlassian.net/browse/DIG-1822)

# Description
While federating servers Daisie found that if you pass in a token that has no authz for anything to the query service, it will pass that on to Katsu and then Katsu will return a 401 Unauthorized. It should return an empty result, instead.

# To test
1. Build this branch
2. Go to Keycloak http://candig.docker.internal:8080/auth/admin/master/console/
3. Sign in with your admin username/password
4. Switch realms at the left to candig
![image](https://github.com/user-attachments/assets/afd986dd-612e-4d85-b24c-de6631339724)
5. Users->Add User. Fill in username `testtest`, email `test@test.ca`
6. Go to the Credentials tab at the top, create new, password `testtest`
7. Try to sign in at http://candig.docker.internal:5080/ where it'll prompt you to give it a first/last name:
8. Grab a token for this user in the usual manner:
```
 CURL_OUTPUT=$(curl -s --request POST \                                                                                                                                                                                                                                                                                                                                                       
   --url 'http://candig.docker.internal:8080/auth/realms/candig/protocol/openid-connect/token' \                                                                                                                                                                                                                                                                                              
   --header 'Content-Type: application/x-www-form-urlencoded' \                                                                                                                                                                                                                                                                                                                               
   --data grant_type=password \                                                                                                                                                                                                                                                                                                                                                               
   --data client_id=local_candig \                                                                                                                                                                                                                                                                                                                                                            
   --data client_secret=$CANDIG_CLIENT_SECRET \                                                                                                                                                                                                                                                                                                                                               
   --data username=testtest \                                                                                                                                                                                                                                                                                                                                                                 
   --data password=testtest \                                                                                                                                                                                                                                                                                                                                                                 
   --data scope=openid                                                                                                                                                                                                                                                                                                                                                                        
 )
```
9.  `curl candig.docker.internal:5080/query/query -H "Authorization: Bearer $TOKEN"`
10. This should now return an empty response instead of an error.

[DIG-1822]: https://candig.atlassian.net/browse/DIG-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ