### PR TITLE
Switch Query from Alpine to Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,14 @@
 ARG venv_python
-ARG alpine_version
-FROM python:${venv_python}-alpine${alpine_version}
+FROM python:${venv_python}
 
 LABEL Maintainer="CanDIG Project"
 LABEL "candigv2"="query_app"
 
 USER root
 
-RUN addgroup -S candig && adduser -S candig -G candig
+RUN groupadd -r candig && useradd -r -g candig candig
 
-RUN apk update
-
-RUN apk add --no-cache \
-	autoconf \
-	automake \
-	make \
-	gcc \
-	perl \
-	bash \
-	build-base \
-	musl-dev \
-	zlib-dev \
-	bzip2-dev \
-	xz-dev \
-	libcurl \
-	linux-headers \
-	curl \
-	curl-dev \
-	yaml-dev \
-	pcre-dev \
-	git \
-	sqlite \
- 	libffi-dev
+RUN apt-get update
 
 COPY requirements.txt /app/query_server/requirements.txt
 
@@ -44,7 +21,5 @@ WORKDIR /app/query_server
 RUN chown -R candig:candig /app/query_server
 
 USER candig
-
-RUN touch initial_setup
 
 ENTRYPOINT ["bash", "entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL "candigv2"="query_app"
 
 USER root
 
-RUN groupadd -r candig && useradd -r -g candig candig
+RUN groupadd -r candig && useradd -rm candig -g candig
 
 RUN apt-get update
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
-if [[ -f "initial_setup" ]]; then
-    sed -i s@\<HTSGET_URL\>@$CANDIG_HTSGET_URL@ config.ini
-    sed -i s@\<KATSU_URL\>@$CANDIG_KATSU_URL@ config.ini
-    sed -i s@\<OPA_URL\>@$OPA_URL@ config.ini
-
-    rm initial_setup
-fi
+sed -i s@\<HTSGET_URL\>@$CANDIG_HTSGET_URL@ config.ini
+sed -i s@\<KATSU_URL\>@$CANDIG_KATSU_URL@ config.ini
+sed -i s@\<OPA_URL\>@$OPA_URL@ config.ini
 
 cd query_server
 gunicorn -k uvicorn.workers.UvicornWorker server:app


### PR DESCRIPTION
Switch from Alpine to Debian, and remove the sort-of unnecessary `initial_setup` sentinel.