### PR TITLE
Add discovery auth call

### DIFF
--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -101,6 +101,22 @@ paths:
                                 $ref: '#/components/schemas/DiscoveryProgramBody'
                 5XX:
                     $ref: "#/components/responses/5xxServerError"
+    /discovery:
+        get:
+            summary: Get discovery overview endpoint calls
+            operationId: query_operations.discovery
+            parameters:
+                - $ref: "#/components/parameters/discoveryTargetPathParam"
+                - $ref: "#/components/parameters/discoveryTargetServiceParam"
+            responses:
+                200:
+                    description: Success
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/DiscoveryResponse'
+                5XX:
+                    $ref: "#/components/responses/5xxServerError"
     /whoami:
         get:
             summary: Retrieve the user key (usually the email) for the currently logged-in user
@@ -202,6 +218,19 @@ components:
             required: false
             schema:
                 $ref: '#/components/schemas/IntField'
+        discoveryTargetServiceParam:
+            name: targetService
+            in: query
+            required: false
+            schema:
+                type: string
+                default: katsu
+        discoveryTargetPathParam:
+            name: targetPath
+            in: query
+            required: false
+            schema:
+                type: string
 #        sessionIDParam:
 #            in: query
 #            name: session_id
@@ -256,6 +285,9 @@ components:
                 programs:
                     type: array
                     description: Per-program summary statistics
+        DiscoveryResponse:
+            type: object
+            additionalProperties: true
         UserInfo:
             type: object
             description: Information about a user

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -452,7 +452,8 @@ def discovery():
         return {"error": "User is not CanDIG authorized"}, 403
 
     headers = get_headers()
-
+    headers.pop("Authorization", None)
+    
     # Extract from query parameters
     target_service = request.args.get("targetService", "katsu")
     target_path = request.args.get("targetPath")
@@ -460,8 +461,11 @@ def discovery():
     if target_service == "katsu":
         url = f"{config.KATSU_URL}/{target_path}"
         response = requests.get(url, headers=headers)
-        ret_val = safe_get_response_json(response, "Katsu discovery")
-        return ret_val, 200
+
+        if response.ok:
+            return response.text, 200
+        else:
+            return {"error": "Failed to fetch data from Katsu"}, response.status_code
 
     return {"error": "Invalid target service"}, 400
 

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -6,7 +6,7 @@ import requests
 import connexion
 import secrets
 import urllib
-from flask import request
+from flask import request, Response
 from authx.auth import get_user_id, get_auth_token, is_user_candig_authorized
 from candigv2_logging.logging import CanDIGLogger
 
@@ -462,8 +462,10 @@ def discovery():
         url = f"{config.KATSU_URL}/{target_path}"
         response = requests.get(url, headers=headers)
 
+        outheaders = {"Content-Type": "application/json"}
+
         if response.ok:
-            return response.text, 200
+            return Response(response=response.text, status=200, headers=outheaders)
         else:
             return {"error": "Failed to fetch data from Katsu"}, response.status_code
 

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -6,6 +6,7 @@ import requests
 import connexion
 import secrets
 import urllib
+from flask import request
 from authx.auth import get_user_id, get_auth_token, is_user_candig_authorized
 from candigv2_logging.logging import CanDIGLogger
 
@@ -40,7 +41,6 @@ def safe_get_response_json(response, name):
     if not response.ok:
         raise Exception(f"Could not get {name} response: {response.status_code} {response.text}")
     return response.json()
-
 
 def get_headers():
     # Add a service token to the headers so that other services will know this is from the query service:
@@ -445,6 +445,25 @@ def discovery_programs():
     }
 
     return fix_dicts(ret_val), 200
+
+@app.route('/discovery')
+def discovery():
+    if not is_user_candig_authorized(connexion.request):
+        return {"error": "User is not CanDIG authorized"}, 403
+
+    headers = get_headers()
+
+    # Extract from query parameters
+    target_service = request.args.get("targetService", "katsu")
+    target_path = request.args.get("targetPath")
+
+    if target_service == "katsu":
+        url = f"{config.KATSU_URL}/{target_path}"
+        response = requests.get(url, headers=headers)
+        ret_val = safe_get_response_json(response, "Katsu discovery")
+        return ret_val, 200
+
+    return {"error": "Invalid target service"}, 400
 
 @app.route('/discovery/query')
 def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene="", assembly="hg38", exclude_programs=[]):


### PR DESCRIPTION
[Data portal call query for Discovery Calls](https://candig.atlassian.net/browse/DIG-1936)

This PR implements the discovery calls to the Query service, specifically the discovery endpoints for the summary and search pages. It introduces an authentication check to ensure that only authorized CanDIG users can access the service. The following changes have been made:

Authorization Check: Added a verification step to confirm that the user is CanDIG authorized. If not, a 403 error is returned with an appropriate message.

Dynamic Target Service Handling: The endpoint now extracts the targetService and targetPath from the query parameters. If the targetService is set to "katsu," the service constructs a request URL using the Katsu URL and the specified targetPath.

## Linked PR
[Data portal PR](https://github.com/CanDIG/candig-data-portal/pull/208)
[CanDIGv2 PR](https://github.com/CanDIG/CanDIGv2/pull/968)
