### PR TITLE
DIG-2021: Pick up updated htsget quick search results

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -289,12 +289,12 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
         try:
             htsget = query_htsget(headers, gene, assembly, chrom)
 
-            # We need to be able to map specimens, so we'll grab it from Katsu
-            specimen_query_req = requests.get(f"{config.KATSU_URL}/v3/authorized/sample_registrations/?page_size=10000000", headers=headers)
-            specimen_query = safe_get_response_json(specimen_query_req, 'Katsu sample registrations')
-            specimen_mapping = {}
-            for specimen in specimen_query['items']:
-                specimen_mapping[specimen['submitter_sample_id']] = (specimen['submitter_donor_id'], specimen['tumour_normal_designation'])
+            # We need to be able to map sample registrations, so we'll grab it from Katsu
+            samplereg_query_req = requests.get(f"{config.KATSU_URL}/v3/authorized/sample_registrations/?page_size=10000000", headers=headers)
+            samplereg_query = safe_get_response_json(samplereg_query_req, 'Katsu sample registrations')
+            samplereg_mapping = {}
+            for samplereg in samplereg_query['items']:
+                samplereg_mapping[samplereg['submitter_sample_id']] = (samplereg['submitter_donor_id'], samplereg['tumour_normal_designation'])
 
             # genomic_query_info contains ALL matches from every dataset
             # This is meant to be used to fill out the summary stats ONLY
@@ -314,21 +314,21 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
                     id = case_data['biosampleId'].split('~')
                     if len(id) > 1:
                         case_data['program_id'] = id[0]
-                        submitter_specimen_id = id[1]
-                        case_data['submitter_specimen_id'] = submitter_specimen_id
-                        if submitter_specimen_id in specimen_mapping:
-                            case_data['donor_id'] = specimen_mapping[submitter_specimen_id][0]
-                            case_data['tumour_normal_designation'] = specimen_mapping[submitter_specimen_id][1]
+                        submitter_sample_id = id[1]
+                        case_data['submitter_sample_id'] = submitter_sample_id
+                        if submitter_sample_id in samplereg_mapping:
+                            case_data['donor_id'] = samplereg_mapping[submitter_sample_id][0]
+                            case_data['tumour_normal_designation'] = samplereg_mapping[submitter_sample_id][1]
                         else:
                             logger.error(f"Could not find donor mapping for {case_data}")
-                            case_data['donor_id'] = submitter_specimen_id
+                            case_data['donor_id'] = submitter_sample_id
                             case_data['tumour_normal_designation'] = 'Tumour'
                         htsget_found_donors[case_data['donor_id']] = 1
                     else:
                         logger.error(f"Could not parse biosampleId for {case_data}")
                         case_data['program_id'] = None
                         case_data['donor_id'] = None
-                        case_data['submitter_specimen_id'] = case_data['biosampleId']
+                        case_data['submitter_sample_id'] = case_data['biosampleId']
                         case_data['tumour_normal_designation'] = 'Tumour'
                     case_data['position'] = response['variation']['location']['interval']['start']['value']
             # Filter clinical results based on genomic results
@@ -501,11 +501,11 @@ def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene=
     # Cross reference with HTSGet, if necessary
     if gene != "" or chrom != "":
         # First, we need to map all Katsu-identified specimens
-        specimen_mapping = {}
+        samplereg_mapping = {}
         for donor in donors:
             if 'submitter_sample_ids' in donor and type(donor['submitter_sample_ids']) is list:
                 for sample_id in donor['submitter_sample_ids']:
-                    specimen_mapping[f"{donor['program_id']}~{sample_id}"] = donor
+                    samplereg_mapping[f"{donor['program_id']}~{sample_id}"] = donor
 
         try:
             htsget = query_htsget(headers, gene, assembly, chrom)
@@ -515,8 +515,8 @@ def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene=
                 for sample_id in htsget['query_info'][program_id]:
                     # NB: We're allowing the entire donor as long as any specimen matches -- is that what we want?
                     merged_id = f"{program_id}~{sample_id}"
-                    if merged_id in specimen_mapping:
-                        found_donor = specimen_mapping[merged_id]
+                    if merged_id in samplereg_mapping:
+                        found_donor = samplereg_mapping[merged_id]
                         htsget_found_donors[f"{found_donor['program_id']}~{found_donor['submitter_donor_id']}"] = 1
                     else:
                         logger.error(f"Could not find specimen identified in HTSGet: {merged_id}")

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -512,7 +512,7 @@ def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene=
                         found_donor = samplereg_mapping[merged_id]
                         htsget_found_donors[f"{found_donor['program_id']}~{found_donor['submitter_donor_id']}"] = 1
                     else:
-                        logger.error(f"Could not find specimen identified in HTSGet: {merged_id}")
+                        logger.error(f"Could not find sample registration identified in HTSGet: {merged_id}")
             # Filter clinical results based on genomic results
             donors = [donor for donor in donors if f"{donor['program_id']}~{donor['submitter_donor_id']}" in htsget_found_donors]
 

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -305,42 +305,35 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
             #    sample_ids = genomic_query_info[program]
 
             htsget_found_donors = {}
-            responses = htsget['response'] if 'response' in htsget else []
-            for response in responses:
-                for case_data in response['caseLevelData']:
-                    if 'biosampleId' not in case_data:
-                        logger.error(f"Could not parse htsget response for {case_data}")
-                        continue
-                    id = case_data['biosampleId'].split('~')
-                    if len(id) > 1:
-                        case_data['program_id'] = id[0]
-                        submitter_sample_id = id[1]
-                        case_data['submitter_sample_id'] = submitter_sample_id
-                        if submitter_sample_id in samplereg_mapping:
-                            case_data['donor_id'] = samplereg_mapping[submitter_sample_id][0]
-                            case_data['tumour_normal_designation'] = samplereg_mapping[submitter_sample_id][1]
-                        else:
-                            logger.error(f"Could not find donor mapping for {case_data}")
-                            case_data['donor_id'] = submitter_sample_id
-                            case_data['tumour_normal_designation'] = 'Tumour'
-                        htsget_found_donors[case_data['donor_id']] = 1
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget else []
+            caseLevelData = []
+            for program in response.keys():
+                for item in response[program]:
+                    submitter_sample_id = item["submitter_sample_id"]
+                    case_data = {
+                        "program_id": program,
+                        "submitter_sample_id": submitter_sample_id,
+                        "variant_count": item["variant_count"]
+                    }
+                    if submitter_sample_id in samplereg_mapping:
+                        case_data['donor_id'] = samplereg_mapping[submitter_sample_id][0]
+                        case_data['tumour_normal_designation'] = samplereg_mapping[submitter_sample_id][1]
                     else:
-                        logger.error(f"Could not parse biosampleId for {case_data}")
-                        case_data['program_id'] = None
-                        case_data['donor_id'] = None
-                        case_data['submitter_sample_id'] = case_data['biosampleId']
+                        logger.error(f"Could not find donor mapping for {case_data}")
+                        case_data['donor_id'] = submitter_sample_id
                         case_data['tumour_normal_designation'] = 'Tumour'
-                    case_data['position'] = response['variation']['location']['interval']['start']['value']
+                    htsget_found_donors[case_data['donor_id']] = 1
+                    caseLevelData.append(case_data)
+
             # Filter clinical results based on genomic results
             donors = [donor for donor in donors if donor['submitter_donor_id'] in htsget_found_donors]
             katsu_allowed_donors = {}
             for donor in donors:
                 katsu_allowed_donors[f"{donor['program_id']}~{donor['submitter_donor_id']}"] = 1
-            for response in htsget['response']:
-                for case_data in response['caseLevelData']:
-                    if ('donor_id' in case_data and 'program_id' in case_data and
-                        f"{case_data['program_id']}~{case_data['donor_id']}" in katsu_allowed_donors):
-                        genomic_query.append(case_data)
+            for case_data in caseLevelData:
+                if ('donor_id' in case_data and 'program_id' in case_data and
+                    f"{case_data['program_id']}~{case_data['donor_id']}" in katsu_allowed_donors):
+                    genomic_query.append(case_data)
 
         except Exception as ex:
             logger.error(f"Error while reading HTSGet response: {ex}")


### PR DESCRIPTION
It turns out that the quick search results are very similar to the query_info object, so we can replace it. However, the quick search results don't have specific positions anymore, so I've replaced `case_data["position"]` with `case_data["variant_count"]`.

In addition, I fixed the references to specimens to sample registrations, where applicable, because it was confusing to me.