### PR TITLE
Fixup: Discovery queries weren't adjusted to the new HTSGet endpoint

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -305,9 +305,11 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
             #    sample_ids = genomic_query_info[program]
 
             htsget_found_donors = {}
-            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is dict else {}
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget else {}
             caseLevelData = []
             for program in response.keys():
+                if type(response[program]) is not list:
+                    continue
                 for item in response[program]:
                     submitter_sample_id = item["submitter_sample_id"]
                     case_data = {
@@ -504,8 +506,10 @@ def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene=
             htsget = query_htsget(headers, gene, assembly, chrom)
 
             htsget_found_donors = {}
-            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is dict else {}
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget else {}
             for program in response.keys():
+                if type(response[program]) is not list:
+                    continue
                 for item in response[program]:
                     submitter_sample_id = item["submitter_sample_id"]
                     if submitter_sample_id in samplereg_mapping:

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -305,7 +305,7 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
             #    sample_ids = genomic_query_info[program]
 
             htsget_found_donors = {}
-            response = htsget['estimatedResults'] if 'estimatedResults' in htsget else []
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is list else []
             caseLevelData = []
             for program in response.keys():
                 for item in response[program]:
@@ -504,7 +504,7 @@ def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene=
             htsget = query_htsget(headers, gene, assembly, chrom)
 
             htsget_found_donors = {}
-            response = htsget['estimatedResults'] if 'estimatedResults' in htsget else []
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is list else []
             for program in response.keys():
                 for item in response[program]:
                     submitter_sample_id = item["submitter_sample_id"]

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -498,7 +498,7 @@ def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene=
         for donor in donors:
             if 'submitter_sample_ids' in donor and type(donor['submitter_sample_ids']) is list:
                 for sample_id in donor['submitter_sample_ids']:
-                    samplereg_mapping[f"{donor['program_id']}~{sample_id}"] = donor
+                    samplereg_mapping[sample_id] = donor
 
         try:
             htsget = query_htsget(headers, gene, assembly, chrom)

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -504,15 +504,17 @@ def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene=
             htsget = query_htsget(headers, gene, assembly, chrom)
 
             htsget_found_donors = {}
-            for program_id in htsget['query_info']:
-                for sample_id in htsget['query_info'][program_id]:
-                    # NB: We're allowing the entire donor as long as any specimen matches -- is that what we want?
-                    merged_id = f"{program_id}~{sample_id}"
-                    if merged_id in samplereg_mapping:
-                        found_donor = samplereg_mapping[merged_id]
-                        htsget_found_donors[f"{found_donor['program_id']}~{found_donor['submitter_donor_id']}"] = 1
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget else []
+            for program in response.keys():
+                for item in response[program]:
+                    submitter_sample_id = item["submitter_sample_id"]
+                    if submitter_sample_id in samplereg_mapping:
+                        donor_id = samplereg_mapping[submitter_sample_id][0]
+                        htsget_found_donors[donor_id] = 1
                     else:
-                        logger.error(f"Could not find sample registration identified in HTSGet: {merged_id}")
+                        logger.error(f"Could not find donor mapping for {item}")
+                        donor_id = submitter_sample_id
+                        htsget_found_donors[donor_id] = 1
             # Filter clinical results based on genomic results
             donors = [donor for donor in donors if f"{donor['program_id']}~{donor['submitter_donor_id']}" in htsget_found_donors]
 

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -305,7 +305,7 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
             #    sample_ids = genomic_query_info[program]
 
             htsget_found_donors = {}
-            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is dict else []
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is dict else {}
             caseLevelData = []
             for program in response.keys():
                 for item in response[program]:
@@ -504,7 +504,7 @@ def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene=
             htsget = query_htsget(headers, gene, assembly, chrom)
 
             htsget_found_donors = {}
-            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is dict else []
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is dict else {}
             for program in response.keys():
                 for item in response[program]:
                     submitter_sample_id = item["submitter_sample_id"]

--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -305,7 +305,7 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
             #    sample_ids = genomic_query_info[program]
 
             htsget_found_donors = {}
-            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is list else []
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is dict else []
             caseLevelData = []
             for program in response.keys():
                 for item in response[program]:
@@ -504,7 +504,7 @@ def discovery_query(treatment="", primary_site="", drug_name="", chrom="", gene=
             htsget = query_htsget(headers, gene, assembly, chrom)
 
             htsget_found_donors = {}
-            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is list else []
+            response = htsget['estimatedResults'] if 'estimatedResults' in htsget and type(htsget['estimatedResults']) is dict else []
             for program in response.keys():
                 for item in response[program]:
                     submitter_sample_id = item["submitter_sample_id"]


### PR DESCRIPTION
# Description
It looks like the discovery queries were missed when the `query_info` was removed from HTSGet's return -- this re-adds them.