### PR TITLE
Return a 401 when the user's token was invalid

### DIFF
--- a/query_server/query_operations.py
+++ b/query_server/query_operations.py
@@ -256,12 +256,13 @@ def query(treatment="", primary_site="", drug_name="", systemic_therapy_type="",
     donors_req = requests.get(full_url, headers=headers)
     if not donors_req.ok:
         if donors_req.status_code == 401:
-            # 401 Unauthorized: the user is not allowed to view any donors at this site
-            # The rest of the code should just pass quietly
-            return format_query_response([], [], get_summary_stats([], {}, {}), page, page_size)
+            # 401 Unauthorized: the token is invalid
+            ret_val = format_query_response([], [], get_summary_stats([], {}, {}), page, page_size)
+            return ret_val[0], 401
         else:
             err_msg = f"Could not got Katsu donors response: {donors_req.status_code} {donors_req.text}"
             logger.error(err_msg)
+            # Do not forward the response from Katsu in case of compromising information (due to X-Service-Token)
             raise Exception(err_msg)
     donors = donors_req.json()['items']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ connexion==3.1.0
 connexion[swagger-ui]
 connexion[flask]
 gunicorn>=23.0.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.1
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.2
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 uvicorn[standard]==0.30.6
 werkzeug>=3.1.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Ultra small patch related to https://github.com/CanDIG/candigv2-authx/pull/49 and https://github.com/CanDIG/katsu/pull/297

Before, Katsu was throwing 401 when the user had no datasets authorized, and Query had to sanitize it for the frontend. Now it'll throw 401 when the token given is invalid, and return 200 OK with no data otherwise.