### PR TITLE
Bump candig-logging version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ connexion[swagger-ui]
 connexion[flask]
 gunicorn>=23.0.0
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.2
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.3
 uvicorn[standard]==0.30.6
 werkzeug>=3.1.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Vulnerability found with Dependabot in candig-logging, so we've got to bump the version everywhere