### PR TITLE
DIG-2308: include listen path in openapi

### DIFF
--- a/query_server/config.py
+++ b/query_server/config.py
@@ -10,7 +10,7 @@ config = configparser.ConfigParser(interpolation=None)
 config.read(os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../config.ini"))
 
 AUTHZ = config['authz']
-QUERY_URL = os.getenv("QUERY_URL", f"http://localhost:{config['DEFAULT']['Port']}")
+QUERY_URL = os.getenv("CANDIG_QUERY_URL", f"http://localhost:{config['DEFAULT']['Port']}")
 AGGREGATE_COUNT_THRESHOLD = int(os.getenv("AGGREGATE_COUNT_THRESHOLD", "5"))
 
 PORT = config['DEFAULT']['Port']

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -53,6 +53,30 @@ paths:
                     $ref: "#/components/responses/404NotFoundError"
                 5XX:
                     $ref: "#/components/responses/5xxServerError"
+            x-codeSamples:
+              - lang: 'cURL'
+                label: 'cURL'
+                source: |
+                  curl -X POST "https://your-candig-domain/query/query" \
+                       -H "Authorization: Bearer ${CANDIG_TOKEN}" \
+                       -H "Content-Type: application/json" \
+                       -d '{"pageSize": 10}'
+              - lang: 'Python'
+                label: 'Python (Requests)'
+                source: |
+                  import requests
+                  import os
+        
+                  token = os.getenv("CANDIG_TOKEN")
+                  url = "https://your-candig-domain/query/query"
+                  
+                  headers = {
+                      "Authorization": f"Bearer {token}",
+                      "Content-Type": "application/json"
+                  }
+                  
+                  response = requests.post(url, json={"pageSize": 10}, headers=headers)
+                  print(response.json())
     /genomic_completeness:
         get:
             summary: Retrieve summary statistics on genomic data

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -83,7 +83,7 @@ paths:
                     $ref: "#/components/responses/5xxServerError"
     /discovery/query:
         get:
-            summary: Retrieve summary statistics on the metadata for each program that match the given query parameters.
+            summary: Retrieve summary statistics
             description: Retrieve summary statistics on the metadata for each program that match the given query parameters.
             operationId: query_operations.discovery_query
             parameters:
@@ -122,7 +122,7 @@ paths:
                     $ref: "#/components/responses/5xxServerError"
     /whoami:
         get:
-            summary: Retrieve the user key (usually the email) for the currently logged-in user
+            summary: Retrieve the user key for the currently logged-in user
             description: Retrieve the user key (usually the email) for the currently logged-in user
             operationId: query_operations.whoami
             responses:

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -3,7 +3,7 @@ info:
     title: Query
     version: 1.2.0
 servers:
-    - url: /
+    - url: /query
 security:
     - {}
     - BasicAuth: []

--- a/query_server/openapi.yaml
+++ b/query_server/openapi.yaml
@@ -3,7 +3,7 @@ info:
     title: Query
     version: 1.2.0
 servers:
-    - url: /query
+    - url: https://your-candig-domain/query
 security:
     - {}
     - BasicAuth: []

--- a/query_server/server.py
+++ b/query_server/server.py
@@ -8,7 +8,7 @@ from config import PORT, DEBUG_MODE
 candigv2_logging.logging.initialize()
 
 # Create the application instance
-app = connexion.App(__name__, specification_dir='./')
+app = connexion.FlaskApp(__name__, specification_dir='./')
 app.app.config['SECRET_KEY'] = secrets.token_bytes(32)
 CORS(app.app)
 


### PR DESCRIPTION
Includes the /query part in the url in the openapi servers.

Also fixes a url reference and updates the connexion app instantiation to match the docs.